### PR TITLE
[Sample] made a more real world sample for livedata

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,9 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
+repositories {
+    maven { url 'https://dl.bintray.com/musichin/maven' }
+}
 
 android {
     compileSdkVersion versions.compileSdk
@@ -33,7 +36,8 @@ android {
 }
 
 dependencies {
-
+    implementation 'com.snakydesign.livedataextensions:lives:1.0.1'
+    implementation 'com.github.musichin.reactivelivedata:reactivelivedata:0.14.0'
     implementation project(':databinding-livedata-form')
     implementation project(':rx-form-jdk')
     implementation project(":validators-jdk")
@@ -48,6 +52,7 @@ dependencies {
     implementation deps.android.arch.lifecycle.extensions
     implementation deps.android.arch.lifecycle.reactivestreams
 
+    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
     androidTestImplementation deps.junit
 
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,14 +9,17 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name="br.com.youse.forms.samples.livedata.LiveDataLoginActivity">
+        <activity android:name=".samples.livedata.LiveDataLoginActivity">
             <intent-filter>
                 <category android:name="android.intent.category.LAUNCHER" />
 
                 <action android:name="android.intent.action.MAIN" />
             </intent-filter>
         </activity>
-
+        <activity
+            android:name=".samples.home.HomeActivity"
+            android:label="@string/title_activity_home"
+            android:theme="@style/AppTheme.NoActionBar" />
     </application>
 
 </manifest>

--- a/app/src/main/kotlin/br/com/youse/forms/samples/home/HomeActivity.kt
+++ b/app/src/main/kotlin/br/com/youse/forms/samples/home/HomeActivity.kt
@@ -1,0 +1,23 @@
+package br.com.youse.forms.samples.home
+
+import android.os.Bundle
+import android.support.design.widget.Snackbar
+import android.support.v7.app.AppCompatActivity
+import br.com.youse.forms.R
+
+import kotlinx.android.synthetic.main.activity_home.*
+
+class HomeActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_home)
+        setSupportActionBar(toolbar)
+
+        fab.setOnClickListener { view ->
+            Snackbar.make(view, "Replace with your own action", Snackbar.LENGTH_LONG)
+                    .setAction("Action", null).show()
+        }
+    }
+
+}

--- a/app/src/main/kotlin/br/com/youse/forms/samples/livedata/BindingAdapters.kt
+++ b/app/src/main/kotlin/br/com/youse/forms/samples/livedata/BindingAdapters.kt
@@ -1,0 +1,15 @@
+package br.com.youse.forms.samples.livedata
+
+import android.databinding.BindingAdapter
+import android.view.View
+
+object BindingAdapters {
+    @BindingAdapter("visible")
+    @JvmStatic fun setVisible(view: View, visible: Boolean) {
+        view.visibility =  if (visible) {
+            View.VISIBLE
+        } else {
+            View.GONE
+        }
+    }
+}

--- a/app/src/main/kotlin/br/com/youse/forms/samples/livedata/LiveDataLoginActivity.kt
+++ b/app/src/main/kotlin/br/com/youse/forms/samples/livedata/LiveDataLoginActivity.kt
@@ -45,7 +45,7 @@ class LiveDataLoginActivity : AppCompatActivity() {
         binding.vm = vm
         binding.setLifecycleOwner(this)
 
-        vm.onSubmit.observe(this, object : SingleEventObserver<LoginState>() {
+        vm.onSubmit.observe(this, object : LiveEventObserver<LoginState>() {
             override fun onEventChanged(event: LoginState?) {
                 event?.data?.let {
                     handleSuccess()

--- a/app/src/main/kotlin/br/com/youse/forms/samples/livedata/LiveDataLoginActivity.kt
+++ b/app/src/main/kotlin/br/com/youse/forms/samples/livedata/LiveDataLoginActivity.kt
@@ -23,14 +23,15 @@ SOFTWARE.
  */
 package br.com.youse.forms.samples.livedata
 
-import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProviders
+import android.content.Intent
 import android.databinding.DataBindingUtil
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.widget.Toast
 import br.com.youse.forms.R
 import br.com.youse.forms.databinding.LiveDataActivityBinding
+import br.com.youse.forms.samples.home.HomeActivity
 
 class LiveDataLoginActivity : AppCompatActivity() {
 
@@ -44,10 +45,19 @@ class LiveDataLoginActivity : AppCompatActivity() {
         binding.vm = vm
         binding.setLifecycleOwner(this)
 
-        vm.success.observe(this, Observer {
-            Toast.makeText(this, "Data sent to server \\o/", Toast.LENGTH_SHORT).show()
+        vm.onSubmit.observe(this, object : SingleEventObserver<LoginState>() {
+            override fun onEventChanged(event: LoginState?) {
+                event?.data?.let {
+                    handleSuccess()
+                }
+            }
         })
 
+    }
+
+    fun handleSuccess() {
+        Toast.makeText(this, "Data sent to server \\o/", Toast.LENGTH_SHORT).show()
+        startActivity(Intent(this, HomeActivity::class.java))
     }
 
 

--- a/app/src/main/kotlin/br/com/youse/forms/samples/livedata/LiveEvent.kt
+++ b/app/src/main/kotlin/br/com/youse/forms/samples/livedata/LiveEvent.kt
@@ -3,7 +3,7 @@ package br.com.youse.forms.samples.livedata
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.Observer
 
-class SingleEvent<T>(private val content: T) {
+class LiveEvent<T>(private val content: T) {
     private var consumed = false	
      fun getContent(): T? {	
         return if (!consumed) {	
@@ -15,19 +15,19 @@ class SingleEvent<T>(private val content: T) {
     }	
 }
 
-class SingleLiveEvent<T> : MutableLiveData<SingleEvent<T>>() {
+class MutableLiveEvent<T> : MutableLiveData<LiveEvent<T>>() {
 
     fun setEvent(event: T) {
-        value = SingleEvent(event)
+        value = LiveEvent(event)
     }
 
     fun postEvent(event: T) {
-        postValue(SingleEvent(event))
+        postValue(LiveEvent(event))
     }
 }
 
-abstract class SingleEventObserver<T> : Observer<SingleEvent<T>> {
-    override fun onChanged(t: SingleEvent<T>?) {
+abstract class LiveEventObserver<T> : Observer<LiveEvent<T>> {
+    override fun onChanged(t: LiveEvent<T>?) {
         onEventChanged(t?.getContent())
     }
 

--- a/app/src/main/kotlin/br/com/youse/forms/samples/livedata/LoginViewModel.kt
+++ b/app/src/main/kotlin/br/com/youse/forms/samples/livedata/LoginViewModel.kt
@@ -23,24 +23,33 @@ SOFTWARE.
  */
 package br.com.youse.forms.samples.livedata
 
-import android.arch.lifecycle.LiveDataReactiveStreams
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MediatorLiveData
 import android.arch.lifecycle.MutableLiveData
-import android.arch.lifecycle.Transformations
 import android.arch.lifecycle.ViewModel
 import br.com.youse.forms.livedata.LiveDataForm
 import br.com.youse.forms.validators.MinLengthValidator
 import br.com.youse.forms.validators.RequiredValidator
 import br.com.youse.forms.validators.ValidationStrategy
-import io.reactivex.BackpressureStrategy
-import io.reactivex.Observable
+import com.github.musichin.reactivelivedata.ReactiveLiveData
+import com.github.musichin.reactivelivedata.combineLatestWith
+import com.snakydesign.livedataextensions.*
+import io.reactivex.Single
+import io.reactivex.disposables.CompositeDisposable
+import java.util.concurrent.TimeUnit
 
+data class LoginState(val data: Unit? = null, val error: Throwable? = null)
 class LoginViewModel : ViewModel() {
 
     private val EMAIL_KEY = "email"
     private val PASSWORD_KEY = "password"
 
+    val disposables = CompositeDisposable()
+
     val email = MutableLiveData<CharSequence>()
     val password = MutableLiveData<CharSequence>()
+    val loading = MutableLiveData<Boolean>()
+
 
     private val emailValidations by lazy {
         listOf(RequiredValidator(
@@ -55,18 +64,58 @@ class LoginViewModel : ViewModel() {
     }
 
     val form = LiveDataForm.Builder<String>(strategy = ValidationStrategy.AFTER_SUBMIT)
-            .addFieldValidations(EMAIL_KEY,
-                    email, emailValidations)
-            .addFieldValidations(PASSWORD_KEY,
-                    password,
-                    passwordValidations)
+            .addFieldValidations(EMAIL_KEY, email, emailValidations)
+            .addFieldValidations(PASSWORD_KEY, password, passwordValidations)
             .build()
 
     val onEmailValidationChange = form.onFieldValidationChange[EMAIL_KEY]!!
     val onPasswordValidationChange = form.onFieldValidationChange[PASSWORD_KEY]!!
 
-    val success = Transformations.switchMap(form.onValidSubmit) {
-        LiveDataReactiveStreams.fromPublisher(Observable.just(Unit)
-                .toFlowable(BackpressureStrategy.BUFFER))
+    val submitData = SingleLiveEvent<LoginState>()
+
+    val onSubmit = form.onValidSubmit
+            .doBeforeNext(OnNextAction {
+                loading.value = true
+            })
+            .doAfterNext(OnNextAction {
+                disposables.add(submitFormToApi()
+                        .subscribe({ response ->
+                            submitData.postEvent(LoginState(data = response))
+                        }, { error ->
+                            submitData.postEvent(LoginState(error = error))
+                        }))
+            })
+            .switchMap {
+                submitData
+            }
+            .doAfterNext(OnNextAction {
+                loading.value = false
+            })
+
+    val formEnabled = ReactiveLiveData.combineLatest(form.onFormValidationChange, loading) { isValidForm, isLoading ->
+        if (isLoading == true) {
+            false
+        } else {
+            isValidForm != false
+        }
+    }
+
+    init {
+        loading.value = false
+
+    }
+
+
+    private fun submitFormToApi(): Single<Unit> {
+        return Single.defer {
+            Single.just(Unit)
+                    .delay(1, TimeUnit.SECONDS)
+        }
+    }
+
+
+    override fun onCleared() {
+        super.onCleared()
+        disposables.clear()
     }
 }

--- a/app/src/main/kotlin/br/com/youse/forms/samples/livedata/LoginViewModel.kt
+++ b/app/src/main/kotlin/br/com/youse/forms/samples/livedata/LoginViewModel.kt
@@ -23,8 +23,6 @@ SOFTWARE.
  */
 package br.com.youse.forms.samples.livedata
 
-import android.arch.lifecycle.LiveData
-import android.arch.lifecycle.MediatorLiveData
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
 import br.com.youse.forms.livedata.LiveDataForm
@@ -32,7 +30,6 @@ import br.com.youse.forms.validators.MinLengthValidator
 import br.com.youse.forms.validators.RequiredValidator
 import br.com.youse.forms.validators.ValidationStrategy
 import com.github.musichin.reactivelivedata.ReactiveLiveData
-import com.github.musichin.reactivelivedata.combineLatestWith
 import com.snakydesign.livedataextensions.*
 import io.reactivex.Single
 import io.reactivex.disposables.CompositeDisposable
@@ -71,7 +68,7 @@ class LoginViewModel : ViewModel() {
     val onEmailValidationChange = form.onFieldValidationChange[EMAIL_KEY]!!
     val onPasswordValidationChange = form.onFieldValidationChange[PASSWORD_KEY]!!
 
-    val submitData = SingleLiveEvent<LoginState>()
+    val submitData = MutableLiveEvent<LoginState>()
 
     val onSubmit = form.onValidSubmit
             .doBeforeNext(OnNextAction {

--- a/app/src/main/kotlin/br/com/youse/forms/samples/livedata/SingleEvent.kt
+++ b/app/src/main/kotlin/br/com/youse/forms/samples/livedata/SingleEvent.kt
@@ -1,0 +1,36 @@
+package br.com.youse.forms.samples.livedata
+
+import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.Observer
+
+class SingleEvent<T>(private val content: T) {
+    private var consumed = false	
+     fun getContent(): T? {	
+        return if (!consumed) {	
+            consumed = true	
+            content	
+        } else {	
+            null	
+        }	
+    }	
+}
+
+class SingleLiveEvent<T> : MutableLiveData<SingleEvent<T>>() {
+
+    fun setEvent(event: T) {
+        value = SingleEvent(event)
+    }
+
+    fun postEvent(event: T) {
+        postValue(SingleEvent(event))
+    }
+}
+
+abstract class SingleEventObserver<T> : Observer<SingleEvent<T>> {
+    override fun onChanged(t: SingleEvent<T>?) {
+        onEventChanged(t?.getContent())
+    }
+
+    abstract fun onEventChanged(event: T?)
+
+}

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".samples.home.HomeActivity">
+
+    <android.support.design.widget.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/AppTheme.AppBarOverlay">
+
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/AppTheme.PopupOverlay" />
+
+    </android.support.design.widget.AppBarLayout>
+
+    <include layout="@layout/content_home" />
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="@dimen/fab_margin"
+        app:srcCompat="@android:drawable/ic_dialog_email" />
+
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/content_home.xml
+++ b/app/src/main/res/layout/content_home.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior"
+    tools:context=".samples.home.HomeActivity"
+    tools:showIn="@layout/activity_home">
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/live_data_activity.xml
+++ b/app/src/main/res/layout/live_data_activity.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".LoginActivity">
 
     <data>
 
@@ -10,11 +12,10 @@
 
     </data>
 
-    <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <android.support.constraint.ConstraintLayout
 
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:context=".LoginActivity">
+        android:layout_height="match_parent">
 
 
         <android.support.design.widget.TextInputLayout
@@ -27,11 +28,11 @@
             android:layout_marginRight="16dp"
             android:layout_marginStart="16dp"
             android:layout_marginTop="16dp"
+            app:fieldError="@{vm.onEmailValidationChange}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:fieldError="@{vm.onEmailValidationChange}">
+            app:layout_constraintTop_toTopOf="parent">
 
             <android.support.design.widget.TextInputEditText
                 android:id="@+id/email"
@@ -50,10 +51,10 @@
             android:layout_marginLeft="16dp"
             android:layout_marginRight="16dp"
             android:layout_marginStart="16dp"
+            app:fieldError="@{vm.onPasswordValidationChange}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/emailContainer"
-            app:fieldError="@{vm.onPasswordValidationChange}"
             tools:layout_editor_absoluteY="390dp">
 
             <android.support.design.widget.TextInputEditText
@@ -76,12 +77,29 @@
             android:layout_marginStart="8dp"
             android:layout_marginTop="8dp"
             android:text="Submit"
-            app:formEnabled="@{vm.form.onFormValidationChange}"
-            app:submit="@={vm.form.submit}"
+            app:formEnabled="@{vm.formEnabled}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/passwordContainer" />
+            app:layout_constraintTop_toBottomOf="@+id/passwordContainer"
+            app:submit="@={vm.form.submit}" />
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginRight="8dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:visible="@{vm.loading}" />
 
     </android.support.constraint.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="fab_margin">16dp</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="app_name">Form Sample</string>
     <string name="empty_email_validation_message">Email não pode ficar em branco</string>
     <string name="min_password_length_validation_message">Tamanho minimo de %1$d letras</string>
+    <string name="title_activity_home">HomeActivity</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -9,4 +9,13 @@
         <item name="textColorError">@color/colorError</item>
     </style>
 
+    <style name="AppTheme.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
+    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
+
+    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
+
 </resources>


### PR DESCRIPTION
This PR brings a more real world sample for using livedata to submit a form.

Changes:
- Included a HomeActivity to navigate after a successful login;
- Included a MutableLiveData for loading state in LoginViewModel;

- Included two libraries to make operations over LiveData viable (one provides **onBeforeNext**, **onAfterNext** and another **combineLatest**);

- Included SingleEvent, SingleLiveEvent and SingleEventObserver to deal with config changes and re-subscriptions in a less painful way. (LiveEvent and LiveEventObserver encapsulates LiveEvent, so the calling code don't need to wrap it's data in a LiveEvent directly);

- Moved the RxJava subscription outside the LiveData chain to avoid a re-submission of the form on config changes. **NOTE:** This behavior is not related to form libraries, but LiveData lib.
