### PR TITLE
makes all form flavors to obey a more standardized api

### DIFF
--- a/app/gradle.properties
+++ b/app/gradle.properties
@@ -1,0 +1,1 @@
+android.databinding.enableV2=true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".samples.rx.RxLoginActivity">
+        <activity android:name=".samples.livedata.LiveDataLoginActivity">
             <intent-filter>
                 <category android:name="android.intent.category.LAUNCHER" />
 

--- a/app/src/main/kotlin/br/com/youse/forms/samples/form/FormLoginActivity.kt
+++ b/app/src/main/kotlin/br/com/youse/forms/samples/form/FormLoginActivity.kt
@@ -32,6 +32,7 @@ import android.util.Log
 import android.widget.Toast
 import br.com.youse.forms.R
 import br.com.youse.forms.form.Form
+import br.com.youse.forms.form.IForm
 import br.com.youse.forms.form.IForm.*
 import br.com.youse.forms.form.models.FormField
 import br.com.youse.forms.form.models.ObservableValue
@@ -41,7 +42,7 @@ import br.com.youse.forms.validators.ValidationMessage
 import kotlinx.android.synthetic.main.activity_main.*
 
 class FormLoginActivity : AppCompatActivity(),
-        FieldValidationChange<Int>,
+        IForm.FieldValidationChange<Int>,
         FormValidationChange,
         ValidSubmit<Int>,
         SubmitFailed<Int> {
@@ -85,14 +86,15 @@ class FormLoginActivity : AppCompatActivity(),
         password.addTextChangedListener(getTextWatcher(passwordChanges))
 
         val emailField = FormField(
-                emailContainer.id,
-                emailChanges, emailValidations
+                key = emailContainer.id,
+                input = emailChanges,
+                validators = emailValidations
         )
 
         val passwordField = FormField(
-                passwordContainer.id,
-                passwordChanges,
-                passwordValidations
+                key = passwordContainer.id,
+                input = passwordChanges,
+                validators = passwordValidations
         )
 
         val form = Form.Builder<Int>()
@@ -114,7 +116,6 @@ class FormLoginActivity : AppCompatActivity(),
         val field = findViewById<TextInputLayout>(key)
         field.isErrorEnabled = validations.isNotEmpty()
         field.error = validations.joinToString { it.message }
-
     }
 
     override fun onFormValidationChange(isValid: Boolean) {

--- a/app/src/main/kotlin/br/com/youse/forms/samples/rx/RxLoginActivity.kt
+++ b/app/src/main/kotlin/br/com/youse/forms/samples/rx/RxLoginActivity.kt
@@ -34,6 +34,7 @@ import br.com.youse.forms.rxform.RxField
 import br.com.youse.forms.rxform.RxForm
 import br.com.youse.forms.validators.MinLengthValidator
 import br.com.youse.forms.validators.RequiredValidator
+import br.com.youse.forms.validators.ValidationStrategy
 import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.widget.textChanges
 import io.reactivex.disposables.CompositeDisposable
@@ -64,10 +65,17 @@ class RxLoginActivity : AppCompatActivity() {
         val emailChanges = email.textChanges().map { it.toString() }
         val passwordChanges = password.textChanges().map { it.toString() }
 
-        val emailField = RxField(emailContainer.id, emailChanges, emailValidations)
-        val passwordField = RxField(passwordContainer.id, passwordChanges, passwordValidations)
+        val emailField = RxField(
+                key = emailContainer.id,
+                input = emailChanges,
+                validators = emailValidations)
 
-        form = RxForm.Builder<Int>(submitObservable)
+        val passwordField = RxField(
+                key = passwordContainer.id,
+                input = passwordChanges,
+                validators = passwordValidations)
+
+        form = RxForm.Builder<Int>(submitObservable, strategy = ValidationStrategy.ALL_TIME)
                 .addField(emailField)
                 .addField(passwordField)
                 .build()

--- a/databinding-livedata-form/src/main/kotlin/br/com/youse/forms/livedata/databinding/BindingAdapters.kt
+++ b/databinding-livedata-form/src/main/kotlin/br/com/youse/forms/livedata/databinding/BindingAdapters.kt
@@ -32,7 +32,6 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.view.View
 import android.widget.EditText
-import android.widget.TextView
 import br.com.youse.forms.validators.ValidationMessage
 
 @Suppress("UNUSED")

--- a/form-common/src/main/kotlin/br/com/youse/forms/form/FieldValidationChange.kt
+++ b/form-common/src/main/kotlin/br/com/youse/forms/form/FieldValidationChange.kt
@@ -1,0 +1,12 @@
+package br.com.youse.forms.form
+
+import br.com.youse.forms.validators.ValidationMessage
+
+interface FieldValidationChange<T> {
+    /**
+     * It's called every time a field validation changes.
+     * {@code validation} contains a list of validation messages,
+     * if the validation messages list is empty the field it valid.
+     */
+    fun onFieldValidationChange(validations: List<ValidationMessage>)
+}

--- a/form-common/src/main/kotlin/br/com/youse/forms/form/IForm.kt
+++ b/form-common/src/main/kotlin/br/com/youse/forms/form/IForm.kt
@@ -25,7 +25,6 @@ package br.com.youse.forms.form
 
 import br.com.youse.forms.form.models.FormField
 import br.com.youse.forms.validators.ValidationMessage
-import br.com.youse.forms.validators.Validator
 
 
 interface IForm {
@@ -75,32 +74,22 @@ interface IForm {
         /**
          * Sets a field validation listener.
          */
-        fun setFieldValidationListener(listener: IForm.FieldValidationChange<T>): Builder<T>
+        fun setFieldValidationListener(listener: FieldValidationChange<T>): Builder<T>
 
         /**
          * Sets a form validation listener.
          */
-        fun setFormValidationListener(listener: IForm.FormValidationChange): Builder<T>
+        fun setFormValidationListener(listener: FormValidationChange): Builder<T>
 
         /**
          * Sets a valid submit listener.
          */
-        fun setValidSubmitListener(listener: IForm.ValidSubmit<T>): Builder<T>
+        fun setValidSubmitListener(listener: ValidSubmit<T>): Builder<T>
 
         /**
          * Sets a failed submit listener
          */
-        fun setSubmitFailedListener(listener: IForm.SubmitFailed<T>): Builder<T>
-
-        /**
-         * Adds a field to the builder, it takes a {@code key} to identify the field,
-         * an {@code input} that emits the field value changes and a list
-         * of validators for that field.
-         */
-        fun <R> addField(key: T,
-                         input: IObservableValue<R>,
-                         validators: List<Validator<R>>,
-                         validationTriggers: List<IObservableChange>): IForm.Builder<T>
+        fun setSubmitFailedListener(listener: SubmitFailed<T>): Builder<T>
 
         /**
          * Adds a field to the builder, it takes a {@code field} of FormField type.

--- a/form-common/src/main/kotlin/br/com/youse/forms/form/models/FormField.kt
+++ b/form-common/src/main/kotlin/br/com/youse/forms/form/models/FormField.kt
@@ -23,11 +23,13 @@ SOFTWARE.
  */
 package br.com.youse.forms.form.models
 
+import br.com.youse.forms.form.FieldValidationChange
 import br.com.youse.forms.form.IObservableChange
 import br.com.youse.forms.form.IObservableValue
 import br.com.youse.forms.validators.Validator
 
 class FormField<T, R>(val key: T,
-                      val input: IObservableValue<R>,
-                      val validators: List<Validator<R>>,
+                      val input: IObservableValue<R> = ObservableValue(),
+                      val errors: FieldValidationChange<T>? = null,
+                      val validators: List<Validator<R>> = emptyList(),
                       val validationTriggers: List<IObservableChange> = emptyList())

--- a/form-common/src/test/kotlin/br/com/youse/forms/form/FormTest.kt
+++ b/form-common/src/test/kotlin/br/com/youse/forms/form/FormTest.kt
@@ -23,6 +23,7 @@ SOFTWARE.
  */
 package br.com.youse.forms.form
 
+import br.com.youse.forms.form.models.FormField
 import br.com.youse.forms.form.models.ObservableValue
 import br.com.youse.forms.validators.ValidationMessage
 import br.com.youse.forms.validators.ValidationStrategy
@@ -79,7 +80,7 @@ class FormTest {
     private val ageValidators: List<Validator<Int>> = listOf(object : Validator<Int> {
 
         override fun isValid(input: Int?): Boolean {
-            return input!= null && input >= MIN_AGE_VALUE
+            return input != null && input >= MIN_AGE_VALUE
         }
 
         override fun validationMessage(): ValidationMessage {
@@ -89,7 +90,7 @@ class FormTest {
     }, object : Validator<Int> {
 
         override fun isValid(input: Int?): Boolean {
-            return input!= null && input <= MAX_AGE_VALUE
+            return input != null && input <= MAX_AGE_VALUE
         }
 
         override fun validationMessage(): ValidationMessage {
@@ -110,9 +111,9 @@ class FormTest {
                 Pair(AGE_ID, listOf(TOO_SMALL_MESSAGE)))
 
         Form.Builder<Int>(ValidationStrategy.ALL_TIME)
-                .addField(EMAIL_ID, emailObservable, emailValidators, emptyList())
-                .addField(PASSWORD_ID, passwordObservable, passwordValidators, emptyList())
-                .addField(AGE_ID, ageObservable, ageValidators, emptyList())
+                .addField(FormField(EMAIL_ID, emailObservable, validators = emailValidators, validationTriggers = emptyList()))
+                .addField(FormField(PASSWORD_ID, passwordObservable, validators = passwordValidators, validationTriggers = emptyList()))
+                .addField(FormField(AGE_ID, ageObservable, validators = ageValidators, validationTriggers = emptyList()))
                 .setFieldValidationListener(object : IForm.FieldValidationChange<Int> {
                     var index = 0
                     override fun onFieldValidationChange(key: Int, validations: List<ValidationMessage>) {
@@ -159,9 +160,9 @@ class FormTest {
         var onFailedSubmitCounter = 0
 
         val form = Form.Builder<Int>()
-                .addField(EMAIL_ID, emailObservable, emailValidators, emptyList())
-                .addField(PASSWORD_ID, passwordObservable, passwordValidators, emptyList())
-                .addField(AGE_ID, ageObservable, ageValidators, emptyList())
+                .addField(FormField(EMAIL_ID, emailObservable, validators = emailValidators, validationTriggers = emptyList()))
+                .addField(FormField(PASSWORD_ID, passwordObservable, validators = passwordValidators, validationTriggers = emptyList()))
+                .addField(FormField(AGE_ID, ageObservable, validators = ageValidators, validationTriggers = emptyList()))
                 .setFieldValidationListener(object : IForm.FieldValidationChange<Int> {
 
                     override fun onFieldValidationChange(key: Int, validations: List<ValidationMessage>) {
@@ -249,18 +250,18 @@ class FormTest {
             }
 
             override fun isValid(input: String?): Boolean {
-                return input != null &&  input.contains("@")
+                return input != null && input.contains("@")
             }
         })
 
-        var lastMesasges = listOf<ValidationMessage>()
+        var lastMessages = listOf<ValidationMessage>()
 
         val form = Form.Builder<Int>()
-                .addField(EMAIL_ID, emailObservable, emailValidators, emptyList())
+                .addField(FormField(EMAIL_ID, emailObservable, validators = emailValidators, validationTriggers = emptyList()))
                 .setFieldValidationListener(object : IForm.FieldValidationChange<Int> {
 
                     override fun onFieldValidationChange(key: Int, validations: List<ValidationMessage>) {
-                        lastMesasges = validations
+                        lastMessages = validations
                     }
                 })
                 .build()
@@ -269,15 +270,15 @@ class FormTest {
 
         form.doSubmit()
 
-        assertEquals(lastMesasges.first().message, firstMessage)
+        assertEquals(lastMessages.first().message, firstMessage)
 
         emailObservable.value = " "
 
-        assertEquals(lastMesasges.first().message, secondMessage)
+        assertEquals(lastMessages.first().message, secondMessage)
 
         emailObservable.value = "@"
 
-        assertTrue(lastMesasges.isEmpty())
+        assertTrue(lastMessages.isEmpty())
 
     }
 }

--- a/livedata-form/src/main/kotlin/br/com/youse/forms/livedata/ILiveDataForm.kt
+++ b/livedata-form/src/main/kotlin/br/com/youse/forms/livedata/ILiveDataForm.kt
@@ -1,0 +1,22 @@
+package br.com.youse.forms.livedata
+
+import android.arch.lifecycle.MediatorLiveData
+import android.arch.lifecycle.MutableLiveData
+import br.com.youse.forms.livedata.models.LiveField
+import br.com.youse.forms.validators.ValidationMessage
+
+interface ILiveDataForm<T> {
+    val onFormValidationChange: MediatorLiveData<Boolean>
+    val onSubmitFailed: MutableLiveData<List<Pair<T, List<ValidationMessage>>>>
+    val onValidSubmit: MutableLiveData<Unit>
+    val onFieldValidationChange: MutableLiveData<Pair<T, List<ValidationMessage>>>
+
+    fun doSubmit()
+
+    interface Builder<T> {
+
+        fun <R> addField(field: LiveField<T, R>): LiveDataForm.Builder<T>
+        fun build(): ILiveDataForm<T>
+    }
+
+}

--- a/livedata-form/src/test/kotlin/br/com/youse/forms/livedata/LiveDataFormTest.kt
+++ b/livedata-form/src/test/kotlin/br/com/youse/forms/livedata/LiveDataFormTest.kt
@@ -143,7 +143,7 @@ class LiveDataFormTest {
     private fun validate(afterSubmit: Boolean) {
         val strategy = if (afterSubmit) ValidationStrategy.AFTER_SUBMIT else ValidationStrategy.ALL_TIME
 
-        val form: LiveDataForm<Int> = LiveDataForm.Builder<Int>(strategy = strategy)
+        val form: ILiveDataForm<Int> = LiveDataForm.Builder<Int>(strategy = strategy)
                 .addField(email)
                 .addField(password)
                 .addField(age)

--- a/rx-form-jdk/src/main/kotlin/br/com/youse/forms/rxform/IRxForm.kt
+++ b/rx-form-jdk/src/main/kotlin/br/com/youse/forms/rxform/IRxForm.kt
@@ -24,7 +24,6 @@ SOFTWARE.
 package br.com.youse.forms.rxform
 
 import br.com.youse.forms.validators.ValidationMessage
-import br.com.youse.forms.validators.Validator
 import io.reactivex.Observable
 
 interface IRxForm<T> {
@@ -67,16 +66,6 @@ interface IRxForm<T> {
      * and optionally a validation strategy (AFTER_SUBMIT by default).
      */
     interface Builder<T> {
-
-        /**
-         * Adds a field to the builder, it takes a key to identify the field,
-         * a field observable that emits the field value changes and a list
-         * of validators for that field.
-         */
-        fun <R> addField(key: T,
-                         input: Observable<R>,
-                         validators: List<Validator<R>>,
-                         validationTriggers: List<Observable<Unit>>): Builder<T>
 
         /**
          * Adds a field to the builder, it takes a {code field} of type RxField.

--- a/rx-form-jdk/src/main/kotlin/br/com/youse/forms/rxform/RxField.kt
+++ b/rx-form-jdk/src/main/kotlin/br/com/youse/forms/rxform/RxField.kt
@@ -1,9 +1,12 @@
 package br.com.youse.forms.rxform
 
+import br.com.youse.forms.validators.ValidationMessage
 import br.com.youse.forms.validators.Validator
 import io.reactivex.Observable
+import io.reactivex.subjects.BehaviorSubject
 
 class RxField<T, R>(val key: T,
-                    val input: Observable<R>,
-                    val validators: List<Validator<R>>,
+                    val input: Observable<R> = BehaviorSubject.create(),
+                    val errors: BehaviorSubject<List<ValidationMessage>> = BehaviorSubject.create(),
+                    val validators: List<Validator<R>> = emptyList(),
                     val validationTriggers: List<Observable<Unit>> = emptyList())

--- a/rx-form-jdk/src/test/kotlin/br/com/youse/forms/rxform/RxFormTests.kt
+++ b/rx-form-jdk/src/test/kotlin/br/com/youse/forms/rxform/RxFormTests.kt
@@ -109,9 +109,9 @@ class RxFormTests {
     @Test
     fun shouldValidateAllTheTime() {
         val form = getBuilder<Int>(submit, ValidationStrategy.ALL_TIME)
-                .addField(EMAIL_ID, emailObservable, emailValidators, emptyList())
-                .addField(PASSWORD_ID, passwordObservable, passwordValidators, emptyList())
-                .addField(AGE_ID, ageObservable, ageValidators, emptyList())
+                .addField(RxField(EMAIL_ID, emailObservable, validators = emailValidators))
+                .addField(RxField(PASSWORD_ID, passwordObservable, validators = passwordValidators))
+                .addField(RxField(AGE_ID, ageObservable, validators = ageValidators))
                 .build()
 
         val fieldsSub = form.onFieldValidationChange().test()
@@ -133,14 +133,16 @@ class RxFormTests {
 
         validSubmitSub.assertNoValues().assertNoErrors()
 
+        form.dispose()
+
     }
 
     @Test
     fun shouldExecuteValidationAfterSubmit() {
         val form = getBuilder<Int>(submit)
-                .addField(EMAIL_ID, emailObservable, emailValidators, emptyList())
-                .addField(PASSWORD_ID, passwordObservable, passwordValidators, emptyList())
-                .addField(AGE_ID, ageObservable, ageValidators, emptyList())
+                .addField(RxField(EMAIL_ID, emailObservable, validators = emailValidators))
+                .addField(RxField(PASSWORD_ID, passwordObservable, validators = passwordValidators))
+                .addField(RxField(AGE_ID, ageObservable, validators = ageValidators))
                 .build()
 
         val fieldsSub = form.onFieldValidationChange().test()
@@ -198,14 +200,15 @@ class RxFormTests {
                 Pair(AGE_ID, MIN_AGE_VALUE)
         ))
 
+        form.dispose()
     }
 
     @Test
     fun shouldNotValidateBeforeSubmit() {
         val form = getBuilder<Int>(submit)
-                .addField(EMAIL_ID, emailObservable, emailValidators, emptyList())
-                .addField(PASSWORD_ID, passwordObservable, passwordValidators, emptyList())
-                .addField(AGE_ID, ageObservable, ageValidators, emptyList())
+                .addField(RxField(EMAIL_ID, emailObservable, validators = emailValidators))
+                .addField(RxField(PASSWORD_ID, passwordObservable, validators = passwordValidators))
+                .addField(RxField(AGE_ID, ageObservable, validators = ageValidators))
                 .build()
 
         val fieldsSub = form.onFieldValidationChange().test()
@@ -245,6 +248,7 @@ class RxFormTests {
         submitFailedSub.assertNoValues()
                 .assertNoErrors()
 
+        form.dispose()
     }
 
     @Test
@@ -269,5 +273,7 @@ class RxFormTests {
 
         submitFailedSub.assertNoValues()
                 .assertNoErrors()
+
+        form.dispose()
     }
 }


### PR DESCRIPTION
- LiveField already had a property `errors`, but it was missing from RxField and FormField.
Introduced `LiveDataForm.onFieldValidationChange` to match `RxForm.onFieldValidationChange()` and `Form.Builder.setOnFieldValidationChangeListener()`

- In RxField was introduced a `BehaviorSubject` for `errors` property, but I also changed `input` to have a default value as being a `BehaviorSubject`.
The reason for this change is that I introduced a bug in the latest release so `ALL_TIME` validation strategy was not working for RxForm as the first emission of a field validation was being lost as it was being executed before the `RxForm.onFieldValidationChange()` had a chance to make a subscription.
With a `BehaviorSubject` the last emission will be replayed when some one creates a subscription, which is exactly  what we need to circumvent this problem.
Notice that, simply changing `RxForm.onFieldValidationChange()` to return a `BehaviorSubject` would not be enough as it would emit only the last field validation change and the form may have multiple validations events that should be emitted to the view. So I used an `Observable.merge` to forward each field `errors` in only one method.
 
- In FormField was introduced `FieldValidationChange` interface as `errors`. Note that, this interface is slightly different from `IForm.FieldValidationChange` as the new interface does not send the field key.

- Introduced `ILiveDataForm` and `ILiveDataForm.Builder` to match `IForm` and `IRxForm`.

- Removed `RxForm.Builder.addField` that accepted multiple parameters to create a RxField inside the builder.

- Removed `Form.Builder.addField` that accepted multiple parameters to create a FormField inside the builder.