### PR TITLE
adds ON_SUBMIT validation strategy

### DIFF
--- a/app/src/main/kotlin/br/com/youse/forms/samples/registration/RegistrationActivity.kt
+++ b/app/src/main/kotlin/br/com/youse/forms/samples/registration/RegistrationActivity.kt
@@ -115,7 +115,7 @@ class RegistrationActivity : AppCompatActivity() {
                 input = checkChanges,
                 validators = listOf(requireTrueValidator))
 
-        rxForm = RxForm.Builder<Key>(submit.clicks())
+        rxForm = RxForm.Builder<Key>(submit.clicks(), strategy = ValidationStrategy.ON_SUBMIT)
                 .addField(ageField)
                 .addField(passwordField)
                 .addField(confirmPasswordField)
@@ -129,7 +129,7 @@ class RegistrationActivity : AppCompatActivity() {
                 })
         disposables.add(rxForm.onFormValidationChange()
                 .subscribe {
-                    submit.isEnabled = it
+              //      submit.isEnabled = it
                 })
 
         disposables.add(rxForm.onValidSubmit()

--- a/form-common/src/main/kotlin/br/com/youse/forms/form/Form.kt
+++ b/form-common/src/main/kotlin/br/com/youse/forms/form/Form.kt
@@ -64,9 +64,9 @@ class Form<T>(private val fieldValidationListener: IForm.FieldValidationChange<T
         }
     }
 
-    private fun strategyAllowsValidation(): Boolean {
-        return (strategy == ValidationStrategy.ALL_TIME)
-                ||
+    private fun strategyAllowsValidation(isSubmit: Boolean): Boolean {
+        return (strategy == ValidationStrategy.ALL_TIME) ||
+                (strategy == ValidationStrategy.ON_SUBMIT && isSubmit) ||
                 (strategy == ValidationStrategy.AFTER_SUBMIT && isFormSubmitted == true)
     }
 
@@ -159,7 +159,7 @@ class Form<T>(private val fieldValidationListener: IForm.FieldValidationChange<T
 
         isFormSubmitted = true
 
-        if (strategy == ValidationStrategy.AFTER_SUBMIT) {
+        if (strategyAllowsValidation(true)) {
             validateAllFields()
             notifyFormValidationChangedIfChanged()
         }
@@ -225,7 +225,7 @@ class Form<T>(private val fieldValidationListener: IForm.FieldValidationChange<T
         override fun onChange() {
             val enabled = field.enabled.value ?: false
 
-            if (enabled && strategyAllowsValidation()) {
+            if (enabled && strategyAllowsValidation(false)) {
                 validateField(field)
                 notifyFormValidationChangedIfChanged()
             }
@@ -242,7 +242,7 @@ class Form<T>(private val fieldValidationListener: IForm.FieldValidationChange<T
 
                 lastFieldsMessages.remove(key)
 
-                if (strategyAllowsValidation()) {
+                if (strategyAllowsValidation(false)) {
                     notifyFieldValidationChange(field, emptyList())
                     notifyFormValidationChangedIfChanged()
                 }

--- a/form-common/src/main/kotlin/br/com/youse/forms/validators/ValidationStrategy.kt
+++ b/form-common/src/main/kotlin/br/com/youse/forms/validators/ValidationStrategy.kt
@@ -31,5 +31,9 @@ enum class ValidationStrategy {
     /**
      * Flag to start validating the form only after the first submit event.
      */
-    AFTER_SUBMIT
+    AFTER_SUBMIT,
+    /**
+     * Flag to only validate the form only when a submit event happens.
+     */
+    ON_SUBMIT
 }


### PR DESCRIPTION
With this strategy the form only will be validated when the `form.doSubmit()` method is called.
All changes from input, enabled and validationTriggers are ignored in this strategy.