### PR TITLE
migrated MediatorLiveData to onValidSubmit to improve form subscriptions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/code
     docker:
-      - image: circleci/android:api-28
+      - image: circleci/android:api-28-alpha
     environment:
       JVM_OPTS: -Xms512m -Xmx3072m
     steps:

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 
             'kotlin'          : '1.3.31',
 
-            'androidPlugin'   : '3.6.0-alpha02',
+            'androidPlugin'   : '3.4.2',
 
             'supportLibrary'  : '28.0.0',
             'androidArch'     : '1.1.1',

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@ buildscript {
             'compileSdk'      : 28,
             'targetSdk'       : 28,
 
-            'kotlin'          : '1.3.21',
+            'kotlin'          : '1.3.31',
 
-            'androidPlugin'   : '3.3.2',
+            'androidPlugin'   : '3.6.0-alpha02',
 
             'supportLibrary'  : '28.0.0',
             'androidArch'     : '1.1.1',
@@ -17,6 +17,7 @@ buildscript {
             'constraintLayout': '1.1.2',
             'junit'           : '4.12'
     ]
+
 
     ext.deps = [
             androidPlugin: "com.android.tools.build:gradle:${versions.androidPlugin}",

--- a/form-common/build.gradle
+++ b/form-common/build.gradle
@@ -4,10 +4,10 @@ archivesBaseName = 'form-common'
 
 dependencies {
 
-    compile deps.kotlin.stdlib.common
+    implementation deps.kotlin.stdlib.common
 
-    testCompile deps.kotlin.test.common
-    testCompile deps.kotlin.test.annotations
+    testImplementation  deps.kotlin.test.common
+    testImplementation  deps.kotlin.test.annotations
 }
 
 

--- a/form-jdk/build.gradle
+++ b/form-jdk/build.gradle
@@ -6,10 +6,10 @@ dependencies {
 
     expectedBy project(':form-common')
 
-    compile deps.kotlin.stdlib.jdk
+    implementation deps.kotlin.stdlib.jdk
 
-    testCompile deps.kotlin.test.jdk
-    testCompile deps.kotlin.test.annotations
+    testImplementation deps.kotlin.test.jdk
+    testImplementation deps.kotlin.test.annotations
 }
 
 sourceSets {

--- a/form-js/build.gradle
+++ b/form-js/build.gradle
@@ -8,8 +8,8 @@ archivesBaseName = 'form'
 
 dependencies {
     expectedBy project(':form-common')
-    compile deps.kotlin.stdlib.js
-    testCompile deps.kotlin.test.js
+    implementation deps.kotlin.stdlib.js
+    testImplementation  deps.kotlin.test.js
 }
 
 kotlinFrontend {

--- a/formatters-common/build.gradle
+++ b/formatters-common/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'org.jetbrains.kotlin.platform.common'
 archivesBaseName = 'form-formatters-common'
 
 dependencies {
-    compile project(":form-common")
+    implementation project(":form-common")
 
-    compile deps.kotlin.stdlib.common
-    testCompile deps.kotlin.test.common
-    testCompile deps.kotlin.test.annotations
+    implementation deps.kotlin.stdlib.common
+    testImplementation  deps.kotlin.test.common
+    testImplementation  deps.kotlin.test.annotations
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/formatters-jdk/build.gradle
+++ b/formatters-jdk/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
     expectedBy project(':formatters-common')
 
-    compile project(":form-jdk")
+    api project(":form-jdk")
 
     implementation deps.kotlin.stdlib.jdk
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=br.com.youse.forms
-VERSION_NAME=0.5.0
+VERSION_NAME=0.6.0-SNAPSHOT
 
 POM_DESCRIPTION=Form validation made easy.
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/livedata-form/README.MD
+++ b/livedata-form/README.MD
@@ -8,7 +8,7 @@ How to `LiveDataForm`
 1) Create a `LiveDataForm.Builder<T>()` where `T` is the type of each field key;
 2) Call `builder.addField()` as many `LiveField`s in the form;
 3) Execute the `builder.build()` method to get a hold of a `LiveDataForm` instance;
-4) Observe the `form.onFormValidationChange` MediatorLiveData<Boolean>, this will bootstrap the form validation. Without it the form will not work!!
+4) Observe the `form.onValidSubmit` MediatorLiveData<Boolean>, this will bootstrap the form validation. Without it the form will not work!!
 5) Observe to the other LiveData available from the `LiveDataForm` instance methods;
 6) Bind your `LiveField.input` and `LiveField.errors` to your XML layout or observe them in your Activity/Fragment;
 
@@ -91,11 +91,11 @@ LiveField<T,R> properties
 LiveDataForm events
 --------
 ## LiveDataForm.onFormValidationChange
- - The `LiveDataForm` class uses this `MediatorLiveData as validation bootstrap.
  - It's triggered when the form validation state change. A boolean is used to indicate if the form is valid as a whole or not.
  - This `LiveData` allow you to enable or disable a submit button.
 
 ## LiveDataForm.onValidSubmit
+ - The `LiveDataForm` class uses this `MediatorLiveData as validation bootstrap.
  - It emits when a valid submit happens.
  - This `LiveData` is called to inform you when to send the form data to your server.
 

--- a/livedata-form/src/main/kotlin/br/com/youse/forms/livedata/ILiveDataForm.kt
+++ b/livedata-form/src/main/kotlin/br/com/youse/forms/livedata/ILiveDataForm.kt
@@ -29,9 +29,9 @@ import br.com.youse.forms.livedata.models.LiveField
 import br.com.youse.forms.validators.ValidationMessage
 
 interface ILiveDataForm<T> {
-    val onFormValidationChange: MediatorLiveData<Boolean>
+    val onFormValidationChange: MutableLiveData<Boolean>
     val onSubmitFailed: MutableLiveData<List<Pair<T, List<ValidationMessage>>>>
-    val onValidSubmit: MutableLiveData<Unit>
+    val onValidSubmit: MediatorLiveData<Unit>
     val onFieldValidationChange: MutableLiveData<Pair<T, List<ValidationMessage>>>
 
     fun doSubmit()

--- a/rx-form-jdk/build.gradle
+++ b/rx-form-jdk/build.gradle
@@ -5,13 +5,13 @@ archivesBaseName = 'rxform'
 
 dependencies {
 
-    compile project(":form-jdk")
+    implementation project(":form-jdk")
 
-    compile deps.kotlin.stdlib.jdk
-    compile deps.rx.java
+    implementation deps.kotlin.stdlib.jdk
+    implementation deps.rx.java
 
-    testCompile deps.kotlin.test.jdk
-    testCompile deps.kotlin.test.annotations
+    implementation deps.kotlin.test.jdk
+    implementation deps.kotlin.test.annotations
 }
 
 
@@ -20,7 +20,7 @@ sourceSets {
     test.java.srcDirs += "src/test/kotlin"
 }
 
-sourceCompatibility = "1.7"
-targetCompatibility = "1.7"
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/validators-common/build.gradle
+++ b/validators-common/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'org.jetbrains.kotlin.platform.common'
 archivesBaseName = 'validation-common'
 
 dependencies {
-    compile project(":form-common")
+    implementation project(":form-common")
 
-    compile deps.kotlin.stdlib.common
+    implementation deps.kotlin.stdlib.common
 
-    testCompile deps.kotlin.test.common
-    testCompile deps.kotlin.test.annotations
+    testImplementation  deps.kotlin.test.common
+    testImplementation  deps.kotlin.test.annotations
 }
 
 

--- a/validators-jdk/build.gradle
+++ b/validators-jdk/build.gradle
@@ -6,12 +6,12 @@ dependencies {
 
     expectedBy project(':validators-common')
 
-    compile project(":form-jdk")
+    api project(":form-jdk")
 
-    compile deps.kotlin.stdlib.jdk
+    implementation deps.kotlin.stdlib.jdk
 
-    testCompile deps.kotlin.test.jdk
-    testCompile deps.kotlin.test.annotations
+    testImplementation  deps.kotlin.test.jdk
+    testImplementation  deps.kotlin.test.annotations
 }
 
 sourceSets {


### PR DESCRIPTION
To avoid the need of an empty subscription to `onFormValidationChange` migrated the MediatorLiveData to `onValidSubmit` that is always subscribed.