### PR TITLE
external changes in the errors will be reflected in the internal implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
             'minSdk'       : 16,
             'compileSdk'   : 29,
             'targetSdk'    : 29,
-            'kotlin'       : '1.3.61',
+            'kotlin'       : '1.3.70',
             'androidPlugin': '3.6.1',
             'androidArch'  : '1.1.1',
             'rxJava'       : '2.2.2',

--- a/livedata-form/src/test/kotlin/br/com/youse/forms/livedata/LiveDataFormTest.kt
+++ b/livedata-form/src/test/kotlin/br/com/youse/forms/livedata/LiveDataFormTest.kt
@@ -35,43 +35,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-class TestObserver<T>(private val ld: MutableLiveData<T>) : Observer<T> {
-    private val changes = mutableListOf<T?>()
-    override fun onChanged(t: T?) {
-        changes.add(t)
-    }
-
-    fun observe(): TestObserver<T> {
-        ld.observeForever(this)
-        return this
-    }
-
-    fun dispose(): TestObserver<T> {
-        ld.removeObserver(this)
-        return this
-    }
-
-    fun assertNoValues(): TestObserver<T> {
-        assertEquals(changes.size, 0)
-        return this
-    }
-
-    fun assertAnyValue(): TestObserver<T> {
-        assertTrue(changes.size > 0)
-        return this
-    }
-
-    fun assertValue(t: T): TestObserver<T> {
-        assertEquals(changes.last(), t)
-        return this
-    }
-
-    fun assertSize(size: Int): TestObserver<T> {
-        assertEquals(changes.size, size)
-        return this
-    }
-}
-
 class LiveDataFormTest {
     @get:Rule
     var rule: TestRule = InstantTaskExecutorRule()

--- a/livedata-form/src/test/kotlin/br/com/youse/forms/livedata/TestObserver.kt
+++ b/livedata-form/src/test/kotlin/br/com/youse/forms/livedata/TestObserver.kt
@@ -1,0 +1,43 @@
+package br.com.youse.forms.livedata
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TestObserver<T>(private val ld: MutableLiveData<T>) : Observer<T> {
+    private val changes = mutableListOf<T?>()
+    override fun onChanged(t: T?) {
+        changes.add(t)
+    }
+
+    fun observe(): TestObserver<T> {
+        ld.observeForever(this)
+        return this
+    }
+
+    fun dispose(): TestObserver<T> {
+        ld.removeObserver(this)
+        return this
+    }
+
+    fun assertNoValues(): TestObserver<T> {
+        assertEquals(changes.size, 0)
+        return this
+    }
+
+    fun assertAnyValue(): TestObserver<T> {
+        assertTrue(changes.size > 0)
+        return this
+    }
+
+    fun assertValue(t: T): TestObserver<T> {
+        assertEquals(changes.last(), t)
+        return this
+    }
+
+    fun assertSize(size: Int): TestObserver<T> {
+        assertEquals(changes.size, size)
+        return this
+    }
+}


### PR DESCRIPTION
The main point of this change is to enable the client develop to "clean" the errors from the wrapper implementation (Rx and LiveData) in the wrapped implementation.
I think @uziassantosferreira that a need for this at some moment.